### PR TITLE
[Issue/96] Fix Messagepack compatibility issues with Docker Perl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM perl:latest
+FROM perl:5.36.1
 
 ENV PATH="/root/bystro/bin:/usr/local/go/bin:/root/go/bin/:${PATH}"
 ENV PERL5LIB="/root/perl5/lib/perl5:/root/bystro/lib:${PERL5LIB}"

--- a/install/install-perl-libs.sh
+++ b/install/install-perl-libs.sh
@@ -55,7 +55,6 @@ cpanm install Test::Pod
 # A dependency of Data::MessagePack installation
 cpanm install File::Copy::Recursive
 
-cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
 cpanm --uninstall -f Data::MessagePack
 rm -rf msgpack-perl
 git clone --recursive https://github.com/akotlar/msgpack-perl.git && cd msgpack-perl && git checkout 6fe098dd91e705b12c68d63bcb1f31c369c81e01

--- a/install/install-perl-libs.sh
+++ b/install/install-perl-libs.sh
@@ -41,23 +41,25 @@ cpanm install Math::Round
 cpanm install Sys::CpuAffinity
 
 cpanm install Statistics::Distributions
+cpanm install File::Which
 
 # Needed for bin/annotate.pl
 cpanm install Hash::Merge::Simple
 cpanm install Sort::XS
 # Custom branch of msgpack-perl that uses latest msgpack-c and
 # allows prefer_float32 flag for 5-byte float storage
-cpanm install Module::Install::XSUtil
-cpanm install Module::Install::AuthorTests
+cpanm install Module::Build::XSUtil
+cpanm install Test::LeakTrace
+cpanm install Test::Pod
 
 # A dependency of Data::MessagePack installation
 cpanm install File::Copy::Recursive
-cpanm install File::Which
 
+cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
 cpanm --uninstall -f Data::MessagePack
 rm -rf msgpack-perl
-git clone --recursive https://github.com/akotlar/msgpack-perl.git && cd msgpack-perl
-perl Makefile.PL
-make test
-make install
+git clone --recursive https://github.com/akotlar/msgpack-perl.git && cd msgpack-perl && git checkout 6fe098dd91e705b12c68d63bcb1f31c369c81e01
+perl Build.PL
+perl Build test
+perl Build install
 cd ../ && rm -rf msgpack-perl


### PR DESCRIPTION
* Updates install-perl-libs.sh to use 2023-04-28 upstreamed Data::MessagePack fork https://github.com/akotlar/msgpack-perl/commit/6fe098dd91e705b12c68d63bcb1f31c369c81e01
* Pins perl version and Data:MessagePack version