### PR TITLE
[search2/save] Cleanup search2, enable by default

### DIFF
--- a/.initialize_conda_env.sh
+++ b/.initialize_conda_env.sh
@@ -1,15 +1,15 @@
 # Follow https://docs.conda.io/en/latest/miniconda.html to install miniconda
 # Call this using "source .initialize_conda_env.sh"
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 if { conda env list | grep 'bystro'; } >/dev/null 2>&1; then
     echo -e "\n====Environment exists (bystro)====\n"
 else
-    conda create --name bystro python=3.10.9
+    conda create --name bystro python=3.11.3
     conda activate bystro
     pip install -r requirements.txt
 fi
 
 echo -e "\n====Activating environment (bystro) and installing requirements====\n"
 conda activate bystro
-pip install -r $SCRIPT_DIR/requirements.txt -q
+conda install python=3.11.3 -y -q
+find . -name 'requirements.txt' -exec pip install -r {} \;

--- a/.initialize_conda_env.sh
+++ b/.initialize_conda_env.sh
@@ -1,15 +1,16 @@
 # Follow https://docs.conda.io/en/latest/miniconda.html to install miniconda
 # Call this using "source .initialize_conda_env.sh"
-
+version="3.11.3"
 if { conda env list | grep 'bystro'; } >/dev/null 2>&1; then
-    echo -e "\n====Environment exists (bystro)====\n"
+    echo -e "\n====Bystro environment exists, activating and ensuring up to date with Python $version====\n"
+    conda activate bystro
+    conda install python=$version -y -q
 else
-    conda create --name bystro python=3.11.3
+    echo -e "\n====Creating Bystro environemnt with Python $version====\n"
+    conda create --name bystro python=$version -y -q
     conda activate bystro
     pip install -r requirements.txt
 fi
 
-echo -e "\n====Activating environment (bystro) and installing requirements====\n"
-conda activate bystro
-conda install python=3.11.3 -y -q
+echo -e "\n====Installing Python requirements====\n"
 find . -name 'requirements.txt' -exec pip install -r {} \;

--- a/bin/beanstalk_queue_server.pl
+++ b/bin/beanstalk_queue_server.pl
@@ -56,10 +56,6 @@ GetOptions(
 
 my $conf = LoadFile($queueConfigPath);
 
-# Beanstalk servers will be sharded
-my $beanstalkHost  = $conf->{beanstalk_host_1};
-my $beanstalkPort  = $conf->{beanstalk_port_1};
-
 # for jobID specific pings
 # my $annotationStatusChannelBase  = 'annotationStatus:';
 
@@ -100,7 +96,7 @@ if(!$queueConfig) {
 }
 
 my $beanstalk = Beanstalk::Client->new({
-  server    => $conf->{beanstalkd}{host} . ':' . $conf->{beanstalkd}{port},
+  server    => $conf->{beanstalkd}{address}[0],
   default_tube => $queueConfig->{submission},
   connect_timeout => 1,
   encoder => sub { encode_json(\@_) },
@@ -108,7 +104,7 @@ my $beanstalk = Beanstalk::Client->new({
 });
 
 my $beanstalkEvents = Beanstalk::Client->new({
-  server    => $conf->{beanstalkd}{host} . ':' . $conf->{beanstalkd}{port},
+  server    => $conf->{beanstalkd}{address}[0],
   default_tube => $queueConfig->{events},
   connect_timeout => 1,
   encoder => sub { encode_json(\@_) },
@@ -313,7 +309,7 @@ sub coerceInputs {
   my %commmonArgs = (
     config             => $configFilePath,
     publisher => {
-      server => $conf->{beanstalkd}{host} . ':' . $conf->{beanstalkd}{port},
+      server => $conf->{beanstalkd}{address}[0],
       queue  => $queueConfig->{events},
       messageBase => {
         event => $events->{progress},

--- a/config/beanstalk.clean.yml
+++ b/config/beanstalk.clean.yml
@@ -1,6 +1,6 @@
 beanstalkd:
-  host: ~
-  port: ~
+  address:
+    - <host1>:<port1>
   tubes:
     annotation:
       submission: annotation
@@ -13,7 +13,7 @@ beanstalkd:
       events: index_events
     filters:
       submission: filters
-      events: filters_events
+      events: filters_eventsf
   events:
     started : started
     completed : completed

--- a/search2/python/search/index/handler.py
+++ b/search2/python/search/index/handler.py
@@ -1,3 +1,6 @@
+# TODO: allow reading directly from annotation_path or get rid of that possibility in annotator
+# TODO: read delimiters from annotation_conf
+
 import argparse
 import asyncio
 from math import ceil
@@ -7,26 +10,33 @@ import time
 
 from opensearchpy._async.client import AsyncOpenSearch
 from opensearchpy._async import helpers as async_helpers
-from orjson import dumps
-from pystalk import BeanstalkClient
+from orjson import dumps  # pylint: disable=no-name-in-module
+from pystalk import BeanstalkClient  # type: ignore
 from ruamel.yaml import YAML
 
-from search.index.bystro_file import read_annotation_tarball
+from search.index.bystro_file import (
+    read_annotation_tarball,
+)  # pylint: disable=no-name-in-module,import-error
+from search.utils.beanstalkd import Publisher
 
 import ray
 
-
-ray.init(ignore_reinit_error='true', address='auto')
-
-# TODO: allow reading directly from annotation_path or get rid of that possibility in annotator
-# TODO: read delimiters from annotation_conf
+ray.init(ignore_reinit_error="true", address="auto")
 
 n_threads = multiprocessing.cpu_count()
 
 
 @ray.remote
 class Indexer:
-    def __init__(self, search_client_args, progress_tracker, chunk_size=1_000, reporter_batch=15_000):
+    """TODO: Add description here"""
+
+    def __init__(
+        self,
+        search_client_args,
+        progress_tracker,
+        chunk_size=1_000,
+        reporter_batch=15_000,
+    ):
         self.search_client_args = search_client_args
         self.client = AsyncOpenSearch(**self.search_client_args)
         self.progress_tracker = progress_tracker
@@ -35,11 +45,15 @@ class Indexer:
         self.counter = 0
 
     async def run(self, data):
-        resp = await async_helpers.async_bulk(self.client, iter(data), chunk_size=self.chunk_size)
+        resp = await async_helpers.async_bulk(
+            self.client, iter(data), chunk_size=self.chunk_size
+        )
         self.counter += resp[0]
 
         if self.counter >= self.reporter_batch:
-            await asyncio.to_thread(self.progress_tracker.increment.remote, self.counter)
+            await asyncio.to_thread(
+                self.progress_tracker.increment.remote, self.counter
+            )
             self.counter = 0
 
         return resp
@@ -50,25 +64,28 @@ class Indexer:
 
 @ray.remote(num_cpus=0)
 class ProgressReporter:
-    def __init__(self, publisher: dict):
+    """A class to report progress to a beanstalk queue"""
+
+    def __init__(self, publisher: Publisher):
         self.value = 0
         self.publisher = publisher
-        self.client = BeanstalkClient(
-            publisher['host'], publisher['port'], socket_timeout=10)
+        self.message = publisher.message._asdict()
+
+        self.message["data"] = {"progress": 0, "skipped": 0}
+
+        self.client = BeanstalkClient(publisher.host, publisher.port, socket_timeout=10)
 
     def increment(self, count: int):
+        """Increment the counter by processed variant count and report to the beanstalk queue"""
         self.value += count
-        self.publisher['messageBase']['data'] = {
-            "progress": self.value,
-            "skipped": 0
-        }
+        self.message["data"]["progress"] = self.value
 
-        self.client.put_job_into(
-            self.publisher['queue'], dumps(self.publisher['messageBase']))
+        self.client.put_job_into(self.publisher.queue, dumps(self.message))
 
         return self.value
 
     def get_counter(self):
+        """Get the current value of the counter"""
         return self.value
 
 
@@ -86,15 +103,14 @@ class ProgressReporterStub:
 
 
 async def go(
-        index_name: str,
-        tar_path: str,
-        annotation_conf: dict,
-        mapping_conf: dict,
-        search_conf: dict,
-        chunk_size=500,
-        paralleleism_chunk_size=5_000,
-        publisher: dict = None,
-        annotation_path: str = None
+    index_name: str,
+    tar_path: str,
+    mapping_conf: dict,
+    search_conf: dict,
+    chunk_size=500,
+    paralleleism_chunk_size=5_000,
+    publisher: Publisher = None,
+    annotation_path: str = None,
 ):
     assert not (tar_path is not None and annotation_path is not None)
     assert tar_path is not None
@@ -112,45 +128,54 @@ async def go(
     )
 
     if publisher:
-        reporter = ProgressReporter.remote(publisher)
+        reporter = ProgressReporter.remote(publisher)  # pylint: disable=no-member
     else:
-        reporter = ProgressReporterStub.remote()
+        reporter = ProgressReporterStub.remote()  # pylint: disable=no-member
 
     client = AsyncOpenSearch(**search_client_args)
 
-    post_index_settings = mapping_conf['post_index_settings']
-    boolean_map = {x: True for x in mapping_conf['booleanFields']}
+    post_index_settings = mapping_conf["post_index_settings"]
+    boolean_map = {x: True for x in mapping_conf["booleanFields"]}
 
     index_body = {
-        'settings': mapping_conf['index_settings'],
-        'mappings': mapping_conf['mappings'],
+        "settings": mapping_conf["index_settings"],
+        "mappings": mapping_conf["mappings"],
     }
 
     delimiters = {
-        'field': "\t",
+        "field": "\t",
         "allele": ",",
         "position": "|",
         "value": ";",
-        "empty_field": "!"
+        "empty_field": "!",
     }
 
-    if not index_body['settings'].get('number_of_shards'):
+    if not index_body["settings"].get("number_of_shards"):
         file_size = os.path.getsize(tar_path)
-        index_body['settings']['number_of_shards'] = ceil(
-            float(file_size) / float(1e10))
+        index_body["settings"]["number_of_shards"] = ceil(
+            float(file_size) / float(1e10)
+        )
 
     try:
         await client.indices.create(index_name, body=index_body)
     except Exception as e:
         print(e)
 
-    data = read_annotation_tarball(index_name=index_name, tar_path=tar_path,
-                                   boolean_map=boolean_map, delimiters=delimiters,
-                                   chunk_size=paralleleism_chunk_size)
+    data = read_annotation_tarball(
+        index_name=index_name,
+        tar_path=tar_path,
+        boolean_map=boolean_map,
+        delimiters=delimiters,
+        chunk_size=paralleleism_chunk_size,
+    )
 
     start = time.time()
-    actors = [Indexer.remote(search_client_args, progress_tracker=reporter, chunk_size=chunk_size)
-              for x in range(n_threads)]
+    actors = [
+        Indexer.remote( # pylint: disable=no-member
+            search_client_args, progress_tracker=reporter, chunk_size=chunk_size
+        )
+        for x in range(n_threads)
+    ]
     actor_idx = 0
     results = []
     for x in data:
@@ -165,13 +190,13 @@ async def go(
 
     errors = []
     total = 0
-    for x in res:
+    for x in res: # pylint: disable=invalid-name
         total += x[0]
         if x[1]:
             errors.append(",".join(x[1]))
 
     if errors:
-        raise Exception("\n".join(errors))
+        raise ValueError("\n".join(errors))
 
     print(f"Processed {total} records")
 
@@ -179,7 +204,8 @@ async def go(
         await actor.close.remote()
 
     result = await client.indices.put_settings(
-        index=index_name, body=post_index_settings)
+        index=index_name, body=post_index_settings
+    )
 
     print(result)
 
@@ -187,13 +213,11 @@ async def go(
 
     return data.get_header_fields()
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process some config files.")
     parser.add_argument(
         "--tar", type=str, help="Path to the tarball containing the annotation"
-    )
-    parser.add_argument(
-        "--annotation_conf", type=str, help="Path to the genome/assembly config, e.g. hg19.yml"
     )
 
     parser.add_argument(
@@ -216,17 +240,17 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    with open(args.annotation_conf, "r", encoding="utf-8") as f:
-        annotation_conf = YAML(typ="safe").load(f)
-
     with open(args.search_conf, "r", encoding="utf-8") as f:
         search_conf = YAML(typ="safe").load(f)
 
     with open(args.mapping_conf, "r", encoding="utf-8") as f:
         mapping_conf = YAML(typ="safe").load(f)
 
-    asyncio.run(go(index_name=args.index_name,
-                   tar_path=args.tar,
-                   annotation_conf=annotation_conf,
-                   mapping_conf=mapping_conf,
-                   search_conf=search_conf))
+    asyncio.run(
+        go(
+            index_name=args.index_name,
+            tar_path=args.tar,
+            mapping_conf=mapping_conf,
+            search_conf=search_conf,
+        )
+    )

--- a/search2/python/search/index/handler.py
+++ b/search2/python/search/index/handler.py
@@ -15,13 +15,12 @@ from orjson import dumps  # pylint: disable=no-name-in-module
 from pystalk import BeanstalkClient  # type: ignore
 from ruamel.yaml import YAML
 
+import ray
+
 from search.index.bystro_file import ( #type: ignore # pylint: disable=no-name-in-module,import-error
     read_annotation_tarball, # pylint: disable=no-name-in-module
 )
-
 from search.utils.beanstalkd import Publisher
-
-import ray
 
 ray.init(ignore_reinit_error="true", address="auto")
 

--- a/search2/python/search/index/listener.py
+++ b/search2/python/search/index/listener.py
@@ -22,7 +22,7 @@ def _get_config_file_path(config_path_base_dir: str, assembly, suffix: str):
                       assembly + suffix))
 
     if not paths:
-        raise Exception(
+        raise ValueError(
             f"\n\nNo config path found for the assembly {assembly}. Exiting\n\n"
         )
 

--- a/search2/python/search/index/listener.py
+++ b/search2/python/search/index/listener.py
@@ -1,179 +1,15 @@
+"""TODO: Add description here"""
 import argparse
-import asyncio
-
-import glob
 import os
-import traceback
-import time
-from typing import Tuple
+from typing import Optional, Any
 
-from opensearchpy.exceptions import NotFoundError
-from orjson import loads, dumps
-from pystalk import BeanstalkClient, BeanstalkError
 from ruamel.yaml import YAML
 
 from search.index.handler import go
-
-# TODO: Allow passing directory for logs
-
-
-def _get_config_file_path(config_path_base_dir: str, assembly, suffix: str):
-    paths = glob.glob(os.path.join(config_path_base_dir,
-                      assembly + suffix))
-
-    if not paths:
-        raise ValueError(
-            f"\n\nNo config path found for the assembly {assembly}. Exiting\n\n"
-        )
-
-    if len(paths) > 1:
-        print("\n\nMore than 1 config path found, choosing first")
-
-    return paths[0]
-
-
-def _coerce_inputs(
-    job_details,
-    job_id,
-    publisher_host,
-    publisher_port,
-    progress_event,
-    event_queue,
-    config_path_base_dir,
-    search_config
-) -> Tuple[dict, str]:
-    mapping_config_path = _get_config_file_path(
-        config_path_base_dir, job_details["assembly"], '.mapping.y*ml')
-
-    annotation_config_path = _get_config_file_path(
-        config_path_base_dir, job_details["assembly"], '.y*ml')
-
-    with open(mapping_config_path, 'r', encoding='utf-8') as f:
-        mapping_config = YAML(typ="safe").load(f)
-
-    with open(annotation_config_path, 'r', encoding='utf-8') as f:
-        annotation_config = YAML(typ="safe").load(f)
-
-    log_path = f"{job_details['indexName']}.index.log"
-
-    tar_path = None
-    annotation_path = None
-
-    if job_details.get('inputFileNames').get('archived'):
-        tar_path = os.path.join(
-            job_details['inputDir'], job_details['inputFileNames']['archived'])
-    else:
-        annotation_path = os.path.join(job_details['inputDir'], job_details['inputFileNames']['annotation'])
-
-
-    return {
-        "index_name": job_details["indexName"],
-        "tar_path": tar_path,
-        "annotation_path": annotation_path,
-        "annotation_conf": annotation_config,
-        "mapping_conf": mapping_config,
-        "search_conf": search_config,
-        "publisher": {
-            "host": publisher_host,
-            "port": publisher_port,
-            "queue": event_queue,
-            "messageBase": {
-                "event": progress_event,
-                "queueID": job_id,
-                "submissionID": job_details["submissionID"],
-                "data": None,
-            },
-        },
-    }, log_path
-
-
-def listen(queue_conf: dict, search_conf: dict, config_path_base_dir: str):
-    queue_conf = queue_conf["beanstalkd"]
-
-    if isinstance(queue_conf["host"], str):
-        hosts = (queue_conf["host"],)
-        ports = (queue_conf["port"],)
-    else:
-        hosts = tuple(queue_conf["host"])
-        ports = tuple(queue_conf["port"])
-
-    assert isinstance(hosts, tuple) and isinstance(ports, tuple)
-
-    for event in ("progress", "failed", "started", "completed"):
-        assert event in queue_conf["events"]
-
-    tube_conf = queue_conf["tubes"]["index"]
-    events_conf = queue_conf["events"]
-    clients = tuple(
-        (h, ports[i], BeanstalkClient(h, ports[i], socket_timeout=10))
-        for i, h in enumerate(hosts)
-    )
-
-    i = 0
-    while True:
-        i += 1
-        offset = i % len(hosts)
-        host = clients[offset][0]
-        port = clients[offset][1]
-        client = clients[offset][2]
-
-        client.watch(tube_conf["submission"])
-
-        try:
-            job = client.reserve_job(5)
-            job_data: dict = loads(job.job_data)
-
-            handler_args, _ = _coerce_inputs(
-                job_data,
-                job.job_id,
-                publisher_host=host,
-                publisher_port=port,
-                progress_event=events_conf["progress"],
-                event_queue=tube_conf["events"],
-                config_path_base_dir=config_path_base_dir,
-                search_config=search_conf
-            )
-        except BeanstalkError as err:
-            if err.message == 'TIMED_OUT':
-                continue
-            raise err
-        try:
-            msg = {
-                "event": events_conf["started"],
-                "queueID": job.job_id,
-                "submissionID": job_data["submissionID"]
-            }
-            client.put_job_into(tube_conf["events"], dumps(msg))
-            field_names = asyncio.get_event_loop().run_until_complete(go(**handler_args))
-
-            msg['event'] = events_conf["completed"]
-            msg['indexConfig'] = handler_args['mapping_conf']
-            msg['fieldNames'] = field_names
-
-            client.put_job_into(tube_conf["events"], dumps(msg))
-            client.delete_job(job.job_id)
-        except BeanstalkError as err:
-            print(f"Received error during execution: {err}")
-            client.release_job(job.job_id)
-        except NotFoundError as err:
-            msg = {
-                "event": events_conf["failed"],
-                "reason": "404",
-                "queueID": job.job_id,
-                "submissionID": job_data["submissionID"]
-            }
-
-            traceback.print_exc()
-            client.put_job_into(tube_conf["events"], dumps(msg))
-            client.delete_job(job.job_id)
-        except Exception as err:
-            traceback.print_exc()
-            client.release_job(job.job_id)
-        finally:
-            time.sleep(0.5)
-
+from search.utils.beanstalkd import Publisher, get_config_file_path, listen
 
 def main():
+    """TODO: Add description here"""
     parser = argparse.ArgumentParser(description="Process some config files.")
     parser.add_argument(
         "--conf_dir", type=str, help="Path to the genome/assembly config directory"
@@ -190,15 +26,54 @@ def main():
     )
     args = parser.parse_args()
 
-    config_path_base_dir = args.conf_dir
+    conf_dir = args.conf_dir
     with open(args.queue_conf, "r", encoding="utf-8") as queue_config_file:
         queue_conf = YAML(typ="safe").load(queue_config_file)
 
     with open(args.search_conf, "r", encoding="utf-8") as search_config_file:
         search_conf = YAML(typ="safe").load(search_config_file)
 
-    listen(queue_conf, search_conf, config_path_base_dir)
+    def handler_fn(publisher: Publisher, job_details: dict):
+        m_path = get_config_file_path(conf_dir, job_details["assembly"], '.mapping.y*ml')
 
+        with open(m_path, 'r', encoding='utf-8') as f:
+            mapping_conf = YAML(typ="safe").load(f)
+
+        tar_path: Optional[str] = None
+        annotation_path: Optional[str] = None
+        input_file_names = job_details['inputFileNames']
+
+        if input_file_names.get('archived'):
+            tar_path = os.path.join(
+                job_details['inputDir'], job_details['inputFileNames']['archived'])
+        else:
+            annotation_path = os.path.join(job_details['inputDir'],
+                                           job_details['inputFileNames']['annotation'])
+
+        return go(
+                  index_name=job_details["indexName"],
+                  tar_path=tar_path,
+                  annotation_path=annotation_path,
+                  mapping_conf=mapping_conf,
+                  search_conf=search_conf,
+                  publisher=publisher)
+
+    def submit_msg_fn(base_msg: dict, **_):
+        return base_msg
+
+    def completed_msg_fn(base_msg: dict, job_details: dict, results: Any):
+        m_path = get_config_file_path(conf_dir, job_details["assembly"], '.mapping.y*ml')
+
+        with open(m_path, 'r', encoding='utf-8') as f:
+            mapping_conf = YAML(typ="safe").load(f)
+
+        return {**base_msg, "indexConfig": mapping_conf, "results": results}
+
+    listen(handler_fn=handler_fn,
+           submit_msg_fn=submit_msg_fn,
+           completed_msg_fn=completed_msg_fn,
+           queue_conf=queue_conf,
+           tube='submission')
 
 if __name__ == "__main__":
     main()

--- a/search2/python/search/index/listener.py
+++ b/search2/python/search/index/listener.py
@@ -58,7 +58,7 @@ def main():
                   search_conf=search_conf,
                   publisher=publisher)
 
-    def submit_msg_fn(base_msg: dict, **_):
+    def submit_msg_fn(base_msg: dict, *_, **_):
         return base_msg
 
     def completed_msg_fn(base_msg: dict, job_details: dict, results: Any):

--- a/search2/python/search/index/listener.py
+++ b/search2/python/search/index/listener.py
@@ -66,7 +66,7 @@ def main():
         with open(m_path, 'r', encoding='utf-8') as f:
             mapping_conf = YAML(typ="safe").load(f)
 
-        return {**base_msg, "indexConfig": mapping_conf, "results": results}
+        return {**base_msg, "indexConfig": mapping_conf, "fieldNames": results}
 
     listen(handler_fn=handler_fn,
            submit_msg_fn=submit_msg_fn,

--- a/search2/python/search/index/listener.py
+++ b/search2/python/search/index/listener.py
@@ -6,7 +6,7 @@ from typing import Optional, Any
 from ruamel.yaml import YAML
 
 from search.index.handler import go
-from search.utils.beanstalkd import Publisher, get_config_file_path, listen
+from search.utils.beanstalkd import Publisher, QueueConf, get_config_file_path, listen
 
 def main():
     """TODO: Add description here"""
@@ -50,15 +50,14 @@ def main():
             annotation_path = os.path.join(job_details['inputDir'],
                                            job_details['inputFileNames']['annotation'])
 
-        return go(
-                  index_name=job_details["indexName"],
+        return go(index_name=job_details["indexName"],
                   tar_path=tar_path,
                   annotation_path=annotation_path,
                   mapping_conf=mapping_conf,
                   search_conf=search_conf,
                   publisher=publisher)
 
-    def submit_msg_fn(base_msg: dict, *_, **_):
+    def submit_msg_fn(base_msg: dict, job_details: dict): # pylint: disable=unused-argument
         return base_msg
 
     def completed_msg_fn(base_msg: dict, job_details: dict, results: Any):
@@ -72,8 +71,8 @@ def main():
     listen(handler_fn=handler_fn,
            submit_msg_fn=submit_msg_fn,
            completed_msg_fn=completed_msg_fn,
-           queue_conf=queue_conf,
-           tube='submission')
+           queue_conf=QueueConf(**queue_conf["beanstalkd"]),
+           tube='index')
 
 if __name__ == "__main__":
     main()

--- a/search2/python/search/save/handler.py
+++ b/search2/python/search/save/handler.py
@@ -196,7 +196,7 @@ def _process_query_chunk(query_args: dict, search_client_args: dict, field_names
 
     return resp["hits"]["total"]["value"]
 
-def go( # pylint:disable=invalid-name
+async def go( # pylint:disable=invalid-name
     input_body: dict,
     search_conf: dict,
     publisher: Publisher,
@@ -241,6 +241,8 @@ def go( # pylint:disable=invalid-name
 
         if "sort" in query_no_sort:
             del query_no_sort["sort"]
+        if "track_total_hits" in query_no_sort:
+            del query_no_sort["track_total_hits"]
         del query_no_sort["pit"]
         response = client.count(
             body=query_no_sort, index=input_body["indexName"])
@@ -251,8 +253,7 @@ def go( # pylint:disable=invalid-name
         # minimum 2 required for this to be a slice query
         num_slices = _clamp(math.ceil(n_docs / max_query_size), 1, max_slices)
 
-        written_chunks = [os.path.join(
-            output_dir, f"{input_body['indexName']}_header")]
+        written_chunks = [os.path.join(output_dir, f"{input_body['indexName']}_header")]
 
         header_output = "\t".join(input_body['fieldNames']) + "\n"
         with mgzip.open(written_chunks[-1], "wt", thread=8, blocksize=2*10**8) as fw:

--- a/search2/python/search/save/handler.py
+++ b/search2/python/search/save/handler.py
@@ -30,7 +30,8 @@ default_delimiters = {
     'fieldSep': "\t",
 }
 
-def make_output_names(output_base_path: str, statistics: bool, compress: bool, archive: bool) -> dict:
+def make_output_names(output_base_path: str, statistics: bool,
+                      compress: bool, archive: bool) -> dict:
     """Make a dictionary of output file names based on the output base path and the output options"""
     out = {}
 

--- a/search2/python/search/save/listener.py
+++ b/search2/python/search/save/listener.py
@@ -1,194 +1,18 @@
-import ray
-import time
-import math
-import multiprocessing
-from ray.util.multiprocessing import Pool
-import json
-import pyarrow
-import gzip
-from ray.cluster_utils import Cluster
-import time
-import pickle
-import json
-from collections.abc import Iterable
-from pystalk import BeanstalkClient, BeanstalkError
-from .handler import go
-from typing import ByteString
-from os import path
-import pprint
-from orjson import loads, dumps
-from ruamel.yaml import YAML
+"""TODO: Add description here"""
+
 import argparse
-import glob
-from opensearchpy.exceptions import NotFoundError
-import traceback
-import time
+
+from ruamel.yaml import YAML
+
+from search.save.handler import go
+from search.utils.beanstalkd import QueueConf, listen
+
 required_keys = ("outputBasePath", "assembly", "queryBody", "fieldNames", "indexName")
 optional_keys = ("indexConfig", "pipeline")
 
 
-def _coerce_inputs(
-    job_details,
-    job_id,
-    publisher_host,
-    publisher_port,
-    progress_event,
-    event_queue,
-    config_path_base_dir,
-):
-    job_specific_args = {}
-
-    for key in required_keys:
-        if key not in job_details:
-            raise Exception(f"Missing required key: {key} in job message")
-
-        job_specific_args[key] = job_details[key]
-
-    for key in optional_keys:
-        if key in job_details:
-            job_specific_args[key] = job_details[key]
-
-    config_file_path = _get_config_file_path(
-        config_path_base_dir, job_specific_args["assembly"]
-    )
-
-    if not config_file_path:
-        raise Exception(
-            f"Assembly {job_specific_args['assembly']} doesn't have corresponding config file"
-        )
-
-    common_args = {
-        "config": config_file_path,
-        "publisher": {
-            "host": publisher_host,
-            "port": publisher_port,
-            "queue": event_queue,
-            "messageBase": {
-                "event": progress_event,
-                "queueID": job_id,
-                "submissionID": job_details["submissionID"],
-                "data": None,
-            },
-        },
-        "compress": True,
-        "archive": True,
-        "run_statistics": True,
-    }
-
-    combined_args = {**common_args, **job_specific_args}
-
-    return combined_args
-
-
-def _get_config_file_path(config_path_base_dir: str, assembly):
-    paths = glob.glob(path.join(config_path_base_dir, assembly + ".y*ml"))
-
-    if not paths:
-        raise Exception(
-            f"\n\nNo config path found for the assembly {assembly}. Exiting\n\n"
-        )
-
-    if len(paths) > 1:
-        print("\n\nMore than 1 config path found, choosing first")
-
-    return paths[0]
-
-
-def listen(queue_conf: dict, search_conf: dict, config_path_base_dir: str):
-    """TODO: Listen on beanstalkd here directly"""
-    queue_conf = queue_conf["beanstalkd"]
-
-    if isinstance(queue_conf["host"], str):
-        hosts = (queue_conf["host"],)
-        ports = (queue_conf["port"],)
-    else:
-        hosts = tuple(queue_conf["host"])
-        ports = tuple(queue_conf["port"])
-
-    assert isinstance(hosts, tuple) and isinstance(ports, tuple)
-
-    for event in ("progress", "failed", "started", "completed"):
-        assert event in queue_conf["events"]
-
-    tube_conf = queue_conf["tubes"]["saveFromQuery"]
-    events_conf = queue_conf["events"]
-    clients = tuple(
-        (h, ports[i], BeanstalkClient(h, ports[i], socket_timeout=10))
-        for i, h in enumerate(hosts)
-    )
-
-    pp = pprint.PrettyPrinter(indent=4)
-
-    i = 0
-    while True:
-        i += 1
-        offset = i % len(hosts)
-        host = clients[offset][0]
-        port = clients[offset][1]
-        client = clients[offset][2]
-
-        client.watch(tube_conf["submission"])
-        print('tube_conf["submission"]', tube_conf["submission"])
-        try:
-            job = client.reserve_job(5)
-            job_data: dict = loads(job.job_data)
-
-            # create the annotator
-            input_data: dict = _coerce_inputs(
-                job_data,
-                job.job_id,
-                publisher_host=host,
-                publisher_port=port,
-                progress_event=events_conf["progress"],
-                event_queue=tube_conf["events"],
-                config_path_base_dir=config_path_base_dir,
-            )
-        except BeanstalkError as err:
-            if err.message == "TIMED_OUT":
-                continue
-            raise err
-        try:
-            with open(input_data['config'], 'r', encoding='utf-8') as f:
-                job_config = YAML(typ="safe").load(f)
-
-            msg = {
-                "event": events_conf["started"],
-                "jobConfig": job_config,
-                "queueID": job.job_id,
-                "submissionID": job_data["submissionID"]
-            }
-
-            client.put_job_into(tube_conf["events"], dumps(msg))
-            output_names = go(input_data, search_conf)
-
-            del msg['jobConfig']
-            msg['results'] = {"outputFileNames": output_names}
-            msg['event'] = events_conf["completed"]
-
-            client.put_job_into(tube_conf["events"], dumps(msg))
-            client.delete_job(job.job_id)
-        except BeanstalkError as err:
-            print(f"Received error during execution: {err}")
-            client.release_job(job.job_id)
-        except NotFoundError as err:
-            msg = {
-                "event": events_conf["failed"],
-                "reason": "404",
-                "queueID": job.job_id,
-                "submissionID": job_data["submissionID"]
-            }
-
-            traceback.print_exc()
-            client.put_job_into(tube_conf["events"], dumps(msg))
-            client.delete_job(job.job_id)
-        except Exception as err:
-            traceback.print_exc()
-            client.release_job(job.job_id)
-        finally:
-            time.sleep(0.5)
-
-
 def main():
+    """TODO: Docstring for main."""
     parser = argparse.ArgumentParser(description="Process some config files.")
     parser.add_argument(
         "--conf_dir", type=str, help="Path to the genome/assembly config directory"
@@ -211,7 +35,16 @@ def main():
 
     with open(args.search_conf, "r", encoding="utf-8") as search_config_file:
         search_conf = YAML(typ="safe").load(search_config_file)
-    listen(queue_conf, search_conf, config_path_base_dir)
+
+    listen(
+        fn=go,
+        queue_conf=QueueConf(**queue_conf["beanstalkd"]),
+        search_conf=search_conf,
+        config_path_base_dir=config_path_base_dir,
+        required_keys=required_keys,
+        optional_keys=optional_keys,
+        tube="saveFromQuery",
+    )
 
 
 if __name__ == "__main__":

--- a/search2/python/search/save/listener.py
+++ b/search2/python/search/save/listener.py
@@ -60,7 +60,7 @@ def main():
 
     def handler_fn(publisher: Publisher, job_details: dict):
         input_body = _coerce_inputs(job_details)
-        go(input_body=input_body, search_conf=search_conf, publisher=publisher)
+        return go(input_body=input_body, search_conf=search_conf, publisher=publisher)
 
     def submit_msg_fn(base_msg: dict, job_details: dict):
         config_path = get_config_file_path(config_path_base_dir, job_details['assembly'])
@@ -71,7 +71,7 @@ def main():
         return {**base_msg, "jobConfig": job_config}
 
     def completed_msg_fn(base_msg: dict, job_details: dict, results: Any): # pylint: disable=unused-argument
-        return {**base_msg, "results": results}
+        return {**base_msg, "results": {"outputFileNames": results}}
 
     listen(
         handler_fn=handler_fn,

--- a/search2/python/search/save/listener.py
+++ b/search2/python/search/save/listener.py
@@ -70,7 +70,7 @@ def main():
 
         return {**base_msg, "jobConfig": job_config}
 
-    def completed_msg_fn(base_msg: dict, job_details: dict, results: Any):
+    def completed_msg_fn(base_msg: dict, job_details: dict, results: Any): # pylint: disable=unused-argument
         return {**base_msg, "results": results}
 
     listen(

--- a/search2/python/search/utils/beanstalkd.py
+++ b/search2/python/search/utils/beanstalkd.py
@@ -1,0 +1,184 @@
+"""TODO: Add description here"""
+import glob
+from os import path
+import time
+import traceback
+from typing import NamedTuple, List, Callable
+
+from orjson import loads, dumps  # pylint: disable=no-name-in-module
+from pystalk import BeanstalkClient, BeanstalkError  # type: ignore
+from ruamel.yaml import YAML
+from opensearchpy.exceptions import NotFoundError
+
+
+class QueueConf(NamedTuple):
+    """TODO: Add description here"""
+
+    host: List[str]
+    port: List[str]
+    events: dict
+    tubes: dict
+    beanstalkd: dict
+
+
+def _coerce_inputs(
+    job_details,
+    job_id,
+    publisher_host,
+    publisher_port,
+    progress_event,
+    event_queue,
+    config_path_base_dir,
+    required_keys,
+    optional_keys,
+):
+    job_specific_args = {}
+
+    for key in required_keys:
+        if key not in job_details:
+            raise ValueError(f"Missing required key: {key} in job message")
+
+        job_specific_args[key] = job_details[key]
+
+    for key in optional_keys:
+        if key in job_details:
+            job_specific_args[key] = job_details[key]
+
+    config_file_path = _get_config_file_path(
+        config_path_base_dir, job_specific_args["assembly"]
+    )
+
+    if not config_file_path:
+        raise ValueError(
+            f"Assembly {job_specific_args['assembly']} doesn't have corresponding config file"
+        )
+
+    common_args = {
+        "config": config_file_path,
+        "publisher": {
+            "host": publisher_host,
+            "port": publisher_port,
+            "queue": event_queue,
+            "messageBase": {
+                "event": progress_event,
+                "queueID": job_id,
+                "submissionID": job_details["submissionID"],
+                "data": None,
+            },
+        },
+        "compress": True,
+        "archive": True,
+        "run_statistics": True,
+    }
+
+    combined_args = {**common_args, **job_specific_args}
+
+    return combined_args
+
+
+def _get_config_file_path(config_path_base_dir: str, assembly):
+    paths = glob.glob(path.join(config_path_base_dir, assembly + ".y*ml"))
+
+    if not paths:
+        raise ValueError(
+            f"\n\nNo config path found for the assembly {assembly}. Exiting\n\n"
+        )
+
+    if len(paths) > 1:
+        print("\n\nMore than 1 config path found, choosing first")
+
+    return paths[0]
+
+
+def listen(
+    fn: Callable,  # pylint: disable=invalid-name
+    queue_conf: QueueConf,
+    search_conf: dict,
+    config_path_base_dir: str,
+    required_keys: tuple,
+    optional_keys: tuple,
+    tube: str,
+):
+    """TODO: Listen on beanstalkd here directly"""
+    hosts = queue_conf.host
+    ports = queue_conf.port
+
+    for event in ("progress", "failed", "started", "completed"):
+        assert event in queue_conf.events
+
+    tube_conf = queue_conf.tubes[tube]
+    events_conf = queue_conf.events
+    clients = tuple(
+        (h, ports[i], BeanstalkClient(h, ports[i], socket_timeout=10))
+        for i, h in enumerate(hosts)
+    )
+
+    i = 0
+    while True:
+        i += 1
+        offset = i % len(hosts)
+        host = clients[offset][0]
+        port = clients[offset][1]
+        client = clients[offset][2]
+
+        client.watch(tube_conf["submission"])
+
+        try:
+            job = client.reserve_job(5)
+            job_data: dict = loads(job.job_data)
+
+            # create the annotator
+            input_data: dict = _coerce_inputs(
+                job_data,
+                job.job_id,
+                publisher_host=host,
+                publisher_port=port,
+                progress_event=events_conf["progress"],
+                event_queue=tube_conf["events"],
+                config_path_base_dir=config_path_base_dir,
+                required_keys=required_keys,
+                optional_keys=optional_keys,
+            )
+        except BeanstalkError as err:
+            if err.message == "TIMED_OUT":
+                continue
+            raise err
+        try:
+            with open(input_data["config"], "r", encoding="utf-8") as f:
+                job_config = YAML(typ="safe").load(f)
+
+            msg = {
+                "event": events_conf["started"],
+                "jobConfig": job_config,
+                "queueID": job.job_id,
+                "submissionID": job_data["submissionID"],
+            }
+
+            client.put_job_into(tube_conf["events"], dumps(msg))
+            output_names = fn(input_data, search_conf)
+
+            del msg["jobConfig"]
+            msg["results"] = {"outputFileNames": output_names}
+            msg["event"] = events_conf["completed"]
+
+            client.put_job_into(tube_conf["events"], dumps(msg))
+            client.delete_job(job.job_id)
+        except BeanstalkError as err:
+            print(f"Received error during execution: {err}")
+            client.release_job(job.job_id)
+        except NotFoundError as err:
+            msg = {
+                "event": events_conf["failed"],
+                "reason": "404",
+                "queueID": job.job_id,
+                "submissionID": job_data["submissionID"],
+            }
+
+            traceback.print_exc()
+            client.put_job_into(tube_conf["events"], dumps(msg))
+            client.delete_job(job.job_id)
+        except Exception as err:
+            traceback.print_exc()
+            client.release_job(job.job_id)
+        finally:
+            time.sleep(0.5)

--- a/search2/python/search/utils/beanstalkd.py
+++ b/search2/python/search/utils/beanstalkd.py
@@ -59,7 +59,7 @@ def get_config_file_path(config_path_base_dir: str, assembly: str, suffix: str =
 def _specify_publisher(
     submission_id, job_id, publisher_host, publisher_port, progress_event, event_queue
 ):
-    Publisher(
+    return Publisher(
             host = publisher_host,
             port = publisher_port,
             queue = event_queue,
@@ -110,7 +110,7 @@ def listen(
             job_data = loads(job.job_data)
 
             publisher: Publisher = _specify_publisher(
-                job_data,
+                job_data['submissionID'],
                 job.job_id,
                 publisher_host=host,
                 publisher_port=port,

--- a/search2/requirements.txt
+++ b/search2/requirements.txt
@@ -1,8 +1,9 @@
-maturin==0.14.13
-ray==2.3.0
--f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-jax[cuda]==0.4.4
-pyarrow==11.0.0
+maturin==0.15.1
+ray==2.4.0
+jax==0.4.8
+jaxlib==0.4.7
+numpyro[cpu]==0.11.0
+pyarrow==12.0.0
 pystalk==0.7.0
 orjson==3.8.6
 ruamel.yaml==0.17.21
@@ -12,3 +13,5 @@ mgzip==0.2.1
 Cython==0.29.33
 patchelf==0.17.2
 aiohttp==3.8.4
+mypy==1.2.0
+pylint==2.17.4

--- a/startup.yml
+++ b/startup.yml
@@ -4,12 +4,12 @@ apps:
     interpreter: 'perl'
     args: --type annotation -q config/beanstalk.yml --debug
   - name: BystroSaveServer
-    script: bin/beanstalk_queue_server.pl
-    interpreter: 'perl'
+    script: search2/python/search/save/listener.py
+    interpreter: 'python'
     args:
-      --type saveFromQuery -q config/beanstalk.yml -c config/elastic-config.yml --debug
+      --conf_dir config --queue_conf config/beanstalk.yml --search_conf config/elastic-config2.yml
   - name: BystroIndexServer
-    script: search2/python/search/index/listener.py 
+    script: search2/python/search/index/listener.py
     interpreter: 'python'
     args:
       --conf_dir config --queue_conf config/beanstalk.yml --search_conf config/elastic-config2.yml

--- a/startup.yml
+++ b/startup.yml
@@ -2,7 +2,7 @@ apps:
   - name: BystroAnnotationServer
     script: bin/beanstalk_queue_server.pl
     interpreter: 'perl'
-    args: --type annotation -q config/beanstalk.yml --debug
+    args: -q config/beanstalk.yml --debug
   - name: BystroSaveServer
     script: search2/python/search/save/listener.py
     interpreter: 'python'


### PR DESCRIPTION
* Python search.save and search.index servers are now enabled by default
* Improves code quality of search module (pylint score >8)

Saving has two outstanding tickets before it is feature complete (https://github.com/akotlar/bystro/issues/102, https://github.com/akotlar/bystro/issues/103), but we should begin relying on it now as the missing outputs do not block the annotation->search->save->search loop and by relying on it now we will identify more issues than if we wait.

